### PR TITLE
Add automated test suite for plugin utilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,15 @@
                         "version": "0.1.0",
                         "license": "MIT",
                         "devDependencies": {
-                                "@types/node": "^16.11.6",
+                                "@types/node": "^20.12.7",
                                 "@typescript-eslint/eslint-plugin": "5.29.0",
                                 "@typescript-eslint/parser": "5.29.0",
                                 "builtin-modules": "3.3.0",
                                 "esbuild": "0.17.3",
                                 "obsidian": "latest",
                                 "tslib": "2.4.0",
-                                "typescript": "4.7.4"
+                                "typescript": "4.7.4",
+                                "vitest": "^1.4.0"
                         }
                 },
                 "node_modules/@codemirror/state": {
@@ -42,6 +43,23 @@
                                 "crelt": "^1.0.6",
                                 "style-mod": "^4.1.0",
                                 "w3c-keyname": "^2.2.4"
+                        }
+                },
+                "node_modules/@esbuild/aix-ppc64": {
+                        "version": "0.21.5",
+                        "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+                        "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+                        "cpu": [
+                                "ppc64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "aix"
+                        ],
+                        "engines": {
+                                "node": ">=12"
                         }
                 },
                 "node_modules/@esbuild/android-arm": {
@@ -526,6 +544,26 @@
                         "license": "BSD-3-Clause",
                         "peer": true
                 },
+                "node_modules/@jest/schemas": {
+                        "version": "29.6.3",
+                        "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+                        "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "@sinclair/typebox": "^0.27.8"
+                        },
+                        "engines": {
+                                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+                        }
+                },
+                "node_modules/@jridgewell/sourcemap-codec": {
+                        "version": "1.5.5",
+                        "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+                        "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+                        "dev": true,
+                        "license": "MIT"
+                },
                 "node_modules/@marijn/find-cluster-break": {
                         "version": "1.0.2",
                         "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
@@ -572,6 +610,307 @@
                                 "node": ">= 8"
                         }
                 },
+                "node_modules/@rollup/rollup-android-arm-eabi": {
+                        "version": "4.50.2",
+                        "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.50.2.tgz",
+                        "integrity": "sha512-uLN8NAiFVIRKX9ZQha8wy6UUs06UNSZ32xj6giK/rmMXAgKahwExvK6SsmgU5/brh4w/nSgj8e0k3c1HBQpa0A==",
+                        "cpu": [
+                                "arm"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "android"
+                        ]
+                },
+                "node_modules/@rollup/rollup-android-arm64": {
+                        "version": "4.50.2",
+                        "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.50.2.tgz",
+                        "integrity": "sha512-oEouqQk2/zxxj22PNcGSskya+3kV0ZKH+nQxuCCOGJ4oTXBdNTbv+f/E3c74cNLeMO1S5wVWacSws10TTSB77g==",
+                        "cpu": [
+                                "arm64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "android"
+                        ]
+                },
+                "node_modules/@rollup/rollup-darwin-arm64": {
+                        "version": "4.50.2",
+                        "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.50.2.tgz",
+                        "integrity": "sha512-OZuTVTpj3CDSIxmPgGH8en/XtirV5nfljHZ3wrNwvgkT5DQLhIKAeuFSiwtbMto6oVexV0k1F1zqURPKf5rI1Q==",
+                        "cpu": [
+                                "arm64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "darwin"
+                        ]
+                },
+                "node_modules/@rollup/rollup-darwin-x64": {
+                        "version": "4.50.2",
+                        "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.50.2.tgz",
+                        "integrity": "sha512-Wa/Wn8RFkIkr1vy1k1PB//VYhLnlnn5eaJkfTQKivirOvzu5uVd2It01ukeQstMursuz7S1bU+8WW+1UPXpa8A==",
+                        "cpu": [
+                                "x64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "darwin"
+                        ]
+                },
+                "node_modules/@rollup/rollup-freebsd-arm64": {
+                        "version": "4.50.2",
+                        "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.50.2.tgz",
+                        "integrity": "sha512-QkzxvH3kYN9J1w7D1A+yIMdI1pPekD+pWx7G5rXgnIlQ1TVYVC6hLl7SOV9pi5q9uIDF9AuIGkuzcbF7+fAhow==",
+                        "cpu": [
+                                "arm64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "freebsd"
+                        ]
+                },
+                "node_modules/@rollup/rollup-freebsd-x64": {
+                        "version": "4.50.2",
+                        "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.50.2.tgz",
+                        "integrity": "sha512-dkYXB0c2XAS3a3jmyDkX4Jk0m7gWLFzq1C3qUnJJ38AyxIF5G/dyS4N9B30nvFseCfgtCEdbYFhk0ChoCGxPog==",
+                        "cpu": [
+                                "x64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "freebsd"
+                        ]
+                },
+                "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+                        "version": "4.50.2",
+                        "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.50.2.tgz",
+                        "integrity": "sha512-9VlPY/BN3AgbukfVHAB8zNFWB/lKEuvzRo1NKev0Po8sYFKx0i+AQlCYftgEjcL43F2h9Ui1ZSdVBc4En/sP2w==",
+                        "cpu": [
+                                "arm"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "linux"
+                        ]
+                },
+                "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+                        "version": "4.50.2",
+                        "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.50.2.tgz",
+                        "integrity": "sha512-+GdKWOvsifaYNlIVf07QYan1J5F141+vGm5/Y8b9uCZnG/nxoGqgCmR24mv0koIWWuqvFYnbURRqw1lv7IBINw==",
+                        "cpu": [
+                                "arm"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "linux"
+                        ]
+                },
+                "node_modules/@rollup/rollup-linux-arm64-gnu": {
+                        "version": "4.50.2",
+                        "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.50.2.tgz",
+                        "integrity": "sha512-df0Eou14ojtUdLQdPFnymEQteENwSJAdLf5KCDrmZNsy1c3YaCNaJvYsEUHnrg+/DLBH612/R0xd3dD03uz2dg==",
+                        "cpu": [
+                                "arm64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "linux"
+                        ]
+                },
+                "node_modules/@rollup/rollup-linux-arm64-musl": {
+                        "version": "4.50.2",
+                        "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.50.2.tgz",
+                        "integrity": "sha512-iPeouV0UIDtz8j1YFR4OJ/zf7evjauqv7jQ/EFs0ClIyL+by++hiaDAfFipjOgyz6y6xbDvJuiU4HwpVMpRFDQ==",
+                        "cpu": [
+                                "arm64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "linux"
+                        ]
+                },
+                "node_modules/@rollup/rollup-linux-loong64-gnu": {
+                        "version": "4.50.2",
+                        "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.50.2.tgz",
+                        "integrity": "sha512-OL6KaNvBopLlj5fTa5D5bau4W82f+1TyTZRr2BdnfsrnQnmdxh4okMxR2DcDkJuh4KeoQZVuvHvzuD/lyLn2Kw==",
+                        "cpu": [
+                                "loong64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "linux"
+                        ]
+                },
+                "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+                        "version": "4.50.2",
+                        "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.50.2.tgz",
+                        "integrity": "sha512-I21VJl1w6z/K5OTRl6aS9DDsqezEZ/yKpbqlvfHbW0CEF5IL8ATBMuUx6/mp683rKTK8thjs/0BaNrZLXetLag==",
+                        "cpu": [
+                                "ppc64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "linux"
+                        ]
+                },
+                "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+                        "version": "4.50.2",
+                        "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.50.2.tgz",
+                        "integrity": "sha512-Hq6aQJT/qFFHrYMjS20nV+9SKrXL2lvFBENZoKfoTH2kKDOJqff5OSJr4x72ZaG/uUn+XmBnGhfr4lwMRrmqCQ==",
+                        "cpu": [
+                                "riscv64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "linux"
+                        ]
+                },
+                "node_modules/@rollup/rollup-linux-riscv64-musl": {
+                        "version": "4.50.2",
+                        "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.50.2.tgz",
+                        "integrity": "sha512-82rBSEXRv5qtKyr0xZ/YMF531oj2AIpLZkeNYxmKNN6I2sVE9PGegN99tYDLK2fYHJITL1P2Lgb4ZXnv0PjQvw==",
+                        "cpu": [
+                                "riscv64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "linux"
+                        ]
+                },
+                "node_modules/@rollup/rollup-linux-s390x-gnu": {
+                        "version": "4.50.2",
+                        "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.50.2.tgz",
+                        "integrity": "sha512-4Q3S3Hy7pC6uaRo9gtXUTJ+EKo9AKs3BXKc2jYypEcMQ49gDPFU2P1ariX9SEtBzE5egIX6fSUmbmGazwBVF9w==",
+                        "cpu": [
+                                "s390x"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "linux"
+                        ]
+                },
+                "node_modules/@rollup/rollup-linux-x64-gnu": {
+                        "version": "4.50.2",
+                        "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.50.2.tgz",
+                        "integrity": "sha512-9Jie/At6qk70dNIcopcL4p+1UirusEtznpNtcq/u/C5cC4HBX7qSGsYIcG6bdxj15EYWhHiu02YvmdPzylIZlA==",
+                        "cpu": [
+                                "x64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "linux"
+                        ]
+                },
+                "node_modules/@rollup/rollup-linux-x64-musl": {
+                        "version": "4.50.2",
+                        "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.50.2.tgz",
+                        "integrity": "sha512-HPNJwxPL3EmhzeAnsWQCM3DcoqOz3/IC6de9rWfGR8ZCuEHETi9km66bH/wG3YH0V3nyzyFEGUZeL5PKyy4xvw==",
+                        "cpu": [
+                                "x64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "linux"
+                        ]
+                },
+                "node_modules/@rollup/rollup-openharmony-arm64": {
+                        "version": "4.50.2",
+                        "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.50.2.tgz",
+                        "integrity": "sha512-nMKvq6FRHSzYfKLHZ+cChowlEkR2lj/V0jYj9JnGUVPL2/mIeFGmVM2mLaFeNa5Jev7W7TovXqXIG2d39y1KYA==",
+                        "cpu": [
+                                "arm64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "openharmony"
+                        ]
+                },
+                "node_modules/@rollup/rollup-win32-arm64-msvc": {
+                        "version": "4.50.2",
+                        "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.50.2.tgz",
+                        "integrity": "sha512-eFUvvnTYEKeTyHEijQKz81bLrUQOXKZqECeiWH6tb8eXXbZk+CXSG2aFrig2BQ/pjiVRj36zysjgILkqarS2YA==",
+                        "cpu": [
+                                "arm64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "win32"
+                        ]
+                },
+                "node_modules/@rollup/rollup-win32-ia32-msvc": {
+                        "version": "4.50.2",
+                        "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.50.2.tgz",
+                        "integrity": "sha512-cBaWmXqyfRhH8zmUxK3d3sAhEWLrtMjWBRwdMMHJIXSjvjLKvv49adxiEz+FJ8AP90apSDDBx2Tyd/WylV6ikA==",
+                        "cpu": [
+                                "ia32"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "win32"
+                        ]
+                },
+                "node_modules/@rollup/rollup-win32-x64-msvc": {
+                        "version": "4.50.2",
+                        "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.50.2.tgz",
+                        "integrity": "sha512-APwKy6YUhvZaEoHyM+9xqmTpviEI+9eL7LoCH+aLcvWYHJ663qG5zx7WzWZY+a9qkg5JtzcMyJ9z0WtQBMDmgA==",
+                        "cpu": [
+                                "x64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "win32"
+                        ]
+                },
+                "node_modules/@sinclair/typebox": {
+                        "version": "0.27.8",
+                        "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+                        "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+                        "dev": true,
+                        "license": "MIT"
+                },
                 "node_modules/@types/codemirror": {
                         "version": "5.60.8",
                         "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
@@ -597,11 +936,14 @@
                         "license": "MIT"
                 },
                 "node_modules/@types/node": {
-                        "version": "16.18.126",
-                        "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
-                        "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
+                        "version": "20.19.16",
+                        "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.16.tgz",
+                        "integrity": "sha512-VS6TTONVdgwJwtJr7U+ghEjpfmQdqehLLpg/iMYGOd1+ilaFjdBJwFuPggJ4EAYPDCzWfDUHoIxyVnu+tOWVuQ==",
                         "dev": true,
-                        "license": "MIT"
+                        "license": "MIT",
+                        "dependencies": {
+                                "undici-types": "~6.21.0"
+                        }
                 },
                 "node_modules/@types/tern": {
                         "version": "0.23.9",
@@ -813,13 +1155,115 @@
                         "license": "ISC",
                         "peer": true
                 },
+                "node_modules/@vitest/expect": {
+                        "version": "1.6.1",
+                        "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+                        "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "@vitest/spy": "1.6.1",
+                                "@vitest/utils": "1.6.1",
+                                "chai": "^4.3.10"
+                        },
+                        "funding": {
+                                "url": "https://opencollective.com/vitest"
+                        }
+                },
+                "node_modules/@vitest/runner": {
+                        "version": "1.6.1",
+                        "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+                        "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "@vitest/utils": "1.6.1",
+                                "p-limit": "^5.0.0",
+                                "pathe": "^1.1.1"
+                        },
+                        "funding": {
+                                "url": "https://opencollective.com/vitest"
+                        }
+                },
+                "node_modules/@vitest/runner/node_modules/p-limit": {
+                        "version": "5.0.0",
+                        "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+                        "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "yocto-queue": "^1.0.0"
+                        },
+                        "engines": {
+                                "node": ">=18"
+                        },
+                        "funding": {
+                                "url": "https://github.com/sponsors/sindresorhus"
+                        }
+                },
+                "node_modules/@vitest/runner/node_modules/yocto-queue": {
+                        "version": "1.2.1",
+                        "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+                        "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+                        "dev": true,
+                        "license": "MIT",
+                        "engines": {
+                                "node": ">=12.20"
+                        },
+                        "funding": {
+                                "url": "https://github.com/sponsors/sindresorhus"
+                        }
+                },
+                "node_modules/@vitest/snapshot": {
+                        "version": "1.6.1",
+                        "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+                        "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "magic-string": "^0.30.5",
+                                "pathe": "^1.1.1",
+                                "pretty-format": "^29.7.0"
+                        },
+                        "funding": {
+                                "url": "https://opencollective.com/vitest"
+                        }
+                },
+                "node_modules/@vitest/spy": {
+                        "version": "1.6.1",
+                        "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+                        "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "tinyspy": "^2.2.0"
+                        },
+                        "funding": {
+                                "url": "https://opencollective.com/vitest"
+                        }
+                },
+                "node_modules/@vitest/utils": {
+                        "version": "1.6.1",
+                        "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+                        "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "diff-sequences": "^29.6.3",
+                                "estree-walker": "^3.0.3",
+                                "loupe": "^2.3.7",
+                                "pretty-format": "^29.7.0"
+                        },
+                        "funding": {
+                                "url": "https://opencollective.com/vitest"
+                        }
+                },
                 "node_modules/acorn": {
                         "version": "8.15.0",
                         "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
                         "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
                         "dev": true,
                         "license": "MIT",
-                        "peer": true,
                         "bin": {
                                 "acorn": "bin/acorn"
                         },
@@ -836,6 +1280,19 @@
                         "peer": true,
                         "peerDependencies": {
                                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+                        }
+                },
+                "node_modules/acorn-walk": {
+                        "version": "8.3.4",
+                        "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+                        "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "acorn": "^8.11.0"
+                        },
+                        "engines": {
+                                "node": ">=0.4.0"
                         }
                 },
                 "node_modules/ajv": {
@@ -902,6 +1359,16 @@
                                 "node": ">=8"
                         }
                 },
+                "node_modules/assertion-error": {
+                        "version": "1.1.0",
+                        "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+                        "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+                        "dev": true,
+                        "license": "MIT",
+                        "engines": {
+                                "node": "*"
+                        }
+                },
                 "node_modules/balanced-match": {
                         "version": "1.0.2",
                         "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -948,6 +1415,16 @@
                                 "url": "https://github.com/sponsors/sindresorhus"
                         }
                 },
+                "node_modules/cac": {
+                        "version": "6.7.14",
+                        "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+                        "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+                        "dev": true,
+                        "license": "MIT",
+                        "engines": {
+                                "node": ">=8"
+                        }
+                },
                 "node_modules/callsites": {
                         "version": "3.1.0",
                         "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -957,6 +1434,25 @@
                         "peer": true,
                         "engines": {
                                 "node": ">=6"
+                        }
+                },
+                "node_modules/chai": {
+                        "version": "4.5.0",
+                        "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+                        "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "assertion-error": "^1.1.0",
+                                "check-error": "^1.0.3",
+                                "deep-eql": "^4.1.3",
+                                "get-func-name": "^2.0.2",
+                                "loupe": "^2.3.6",
+                                "pathval": "^1.1.1",
+                                "type-detect": "^4.1.0"
+                        },
+                        "engines": {
+                                "node": ">=4"
                         }
                 },
                 "node_modules/chalk": {
@@ -975,6 +1471,19 @@
                         },
                         "funding": {
                                 "url": "https://github.com/chalk/chalk?sponsor=1"
+                        }
+                },
+                "node_modules/check-error": {
+                        "version": "1.0.3",
+                        "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+                        "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "get-func-name": "^2.0.2"
+                        },
+                        "engines": {
+                                "node": "*"
                         }
                 },
                 "node_modules/color-convert": {
@@ -1007,6 +1516,13 @@
                         "license": "MIT",
                         "peer": true
                 },
+                "node_modules/confbox": {
+                        "version": "0.1.8",
+                        "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+                        "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+                        "dev": true,
+                        "license": "MIT"
+                },
                 "node_modules/crelt": {
                         "version": "1.0.6",
                         "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
@@ -1021,7 +1537,6 @@
                         "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
                         "dev": true,
                         "license": "MIT",
-                        "peer": true,
                         "dependencies": {
                                 "path-key": "^3.1.0",
                                 "shebang-command": "^2.0.0",
@@ -1049,6 +1564,19 @@
                                 }
                         }
                 },
+                "node_modules/deep-eql": {
+                        "version": "4.1.4",
+                        "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+                        "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "type-detect": "^4.0.0"
+                        },
+                        "engines": {
+                                "node": ">=6"
+                        }
+                },
                 "node_modules/deep-is": {
                         "version": "0.1.4",
                         "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1056,6 +1584,16 @@
                         "dev": true,
                         "license": "MIT",
                         "peer": true
+                },
+                "node_modules/diff-sequences": {
+                        "version": "29.6.3",
+                        "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+                        "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+                        "dev": true,
+                        "license": "MIT",
+                        "engines": {
+                                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+                        }
                 },
                 "node_modules/dir-glob": {
                         "version": "3.0.1",
@@ -1356,6 +1894,16 @@
                                 "node": ">=4.0"
                         }
                 },
+                "node_modules/estree-walker": {
+                        "version": "3.0.3",
+                        "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+                        "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "@types/estree": "^1.0.0"
+                        }
+                },
                 "node_modules/esutils": {
                         "version": "2.0.3",
                         "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1365,6 +1913,30 @@
                         "peer": true,
                         "engines": {
                                 "node": ">=0.10.0"
+                        }
+                },
+                "node_modules/execa": {
+                        "version": "8.0.1",
+                        "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+                        "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "cross-spawn": "^7.0.3",
+                                "get-stream": "^8.0.1",
+                                "human-signals": "^5.0.0",
+                                "is-stream": "^3.0.0",
+                                "merge-stream": "^2.0.0",
+                                "npm-run-path": "^5.1.0",
+                                "onetime": "^6.0.0",
+                                "signal-exit": "^4.1.0",
+                                "strip-final-newline": "^3.0.0"
+                        },
+                        "engines": {
+                                "node": ">=16.17"
+                        },
+                        "funding": {
+                                "url": "https://github.com/sindresorhus/execa?sponsor=1"
                         }
                 },
                 "node_modules/fast-deep-equal": {
@@ -1508,12 +2080,50 @@
                         "license": "ISC",
                         "peer": true
                 },
+                "node_modules/fsevents": {
+                        "version": "2.3.3",
+                        "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+                        "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+                        "dev": true,
+                        "hasInstallScript": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "darwin"
+                        ],
+                        "engines": {
+                                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+                        }
+                },
                 "node_modules/functional-red-black-tree": {
                         "version": "1.0.1",
                         "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
                         "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
                         "dev": true,
                         "license": "MIT"
+                },
+                "node_modules/get-func-name": {
+                        "version": "2.0.2",
+                        "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+                        "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+                        "dev": true,
+                        "license": "MIT",
+                        "engines": {
+                                "node": "*"
+                        }
+                },
+                "node_modules/get-stream": {
+                        "version": "8.0.1",
+                        "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+                        "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+                        "dev": true,
+                        "license": "MIT",
+                        "engines": {
+                                "node": ">=16"
+                        },
+                        "funding": {
+                                "url": "https://github.com/sponsors/sindresorhus"
+                        }
                 },
                 "node_modules/glob": {
                         "version": "7.2.3",
@@ -1607,6 +2217,16 @@
                         "peer": true,
                         "engines": {
                                 "node": ">=8"
+                        }
+                },
+                "node_modules/human-signals": {
+                        "version": "5.0.0",
+                        "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+                        "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+                        "dev": true,
+                        "license": "Apache-2.0",
+                        "engines": {
+                                "node": ">=16.17.0"
                         }
                 },
                 "node_modules/ignore": {
@@ -1713,13 +2333,32 @@
                                 "node": ">=8"
                         }
                 },
+                "node_modules/is-stream": {
+                        "version": "3.0.0",
+                        "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+                        "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+                        "dev": true,
+                        "license": "MIT",
+                        "engines": {
+                                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                        },
+                        "funding": {
+                                "url": "https://github.com/sponsors/sindresorhus"
+                        }
+                },
                 "node_modules/isexe": {
                         "version": "2.0.0",
                         "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
                         "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
                         "dev": true,
-                        "license": "ISC",
-                        "peer": true
+                        "license": "ISC"
+                },
+                "node_modules/js-tokens": {
+                        "version": "9.0.1",
+                        "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+                        "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+                        "dev": true,
+                        "license": "MIT"
                 },
                 "node_modules/js-yaml": {
                         "version": "4.1.0",
@@ -1785,6 +2424,23 @@
                                 "node": ">= 0.8.0"
                         }
                 },
+                "node_modules/local-pkg": {
+                        "version": "0.5.1",
+                        "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+                        "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "mlly": "^1.7.3",
+                                "pkg-types": "^1.2.1"
+                        },
+                        "engines": {
+                                "node": ">=14"
+                        },
+                        "funding": {
+                                "url": "https://github.com/sponsors/antfu"
+                        }
+                },
                 "node_modules/locate-path": {
                         "version": "6.0.0",
                         "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -1810,6 +2466,33 @@
                         "license": "MIT",
                         "peer": true
                 },
+                "node_modules/loupe": {
+                        "version": "2.3.7",
+                        "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+                        "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "get-func-name": "^2.0.1"
+                        }
+                },
+                "node_modules/magic-string": {
+                        "version": "0.30.19",
+                        "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+                        "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "@jridgewell/sourcemap-codec": "^1.5.5"
+                        }
+                },
+                "node_modules/merge-stream": {
+                        "version": "2.0.0",
+                        "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+                        "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+                        "dev": true,
+                        "license": "MIT"
+                },
                 "node_modules/merge2": {
                         "version": "1.4.1",
                         "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -1834,6 +2517,19 @@
                                 "node": ">=8.6"
                         }
                 },
+                "node_modules/mimic-fn": {
+                        "version": "4.0.0",
+                        "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+                        "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+                        "dev": true,
+                        "license": "MIT",
+                        "engines": {
+                                "node": ">=12"
+                        },
+                        "funding": {
+                                "url": "https://github.com/sponsors/sindresorhus"
+                        }
+                },
                 "node_modules/minimatch": {
                         "version": "3.1.2",
                         "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -1847,6 +2543,26 @@
                         "engines": {
                                 "node": "*"
                         }
+                },
+                "node_modules/mlly": {
+                        "version": "1.8.0",
+                        "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+                        "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "acorn": "^8.15.0",
+                                "pathe": "^2.0.3",
+                                "pkg-types": "^1.3.1",
+                                "ufo": "^1.6.1"
+                        }
+                },
+                "node_modules/mlly/node_modules/pathe": {
+                        "version": "2.0.3",
+                        "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+                        "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+                        "dev": true,
+                        "license": "MIT"
                 },
                 "node_modules/moment": {
                         "version": "2.29.4",
@@ -1865,6 +2581,25 @@
                         "dev": true,
                         "license": "MIT"
                 },
+                "node_modules/nanoid": {
+                        "version": "3.3.11",
+                        "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+                        "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+                        "dev": true,
+                        "funding": [
+                                {
+                                        "type": "github",
+                                        "url": "https://github.com/sponsors/ai"
+                                }
+                        ],
+                        "license": "MIT",
+                        "bin": {
+                                "nanoid": "bin/nanoid.cjs"
+                        },
+                        "engines": {
+                                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+                        }
+                },
                 "node_modules/natural-compare": {
                         "version": "1.4.0",
                         "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -1872,6 +2607,35 @@
                         "dev": true,
                         "license": "MIT",
                         "peer": true
+                },
+                "node_modules/npm-run-path": {
+                        "version": "5.3.0",
+                        "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+                        "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "path-key": "^4.0.0"
+                        },
+                        "engines": {
+                                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                        },
+                        "funding": {
+                                "url": "https://github.com/sponsors/sindresorhus"
+                        }
+                },
+                "node_modules/npm-run-path/node_modules/path-key": {
+                        "version": "4.0.0",
+                        "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+                        "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+                        "dev": true,
+                        "license": "MIT",
+                        "engines": {
+                                "node": ">=12"
+                        },
+                        "funding": {
+                                "url": "https://github.com/sponsors/sindresorhus"
+                        }
                 },
                 "node_modules/obsidian": {
                         "version": "1.8.7",
@@ -1897,6 +2661,22 @@
                         "peer": true,
                         "dependencies": {
                                 "wrappy": "1"
+                        }
+                },
+                "node_modules/onetime": {
+                        "version": "6.0.0",
+                        "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+                        "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "mimic-fn": "^4.0.0"
+                        },
+                        "engines": {
+                                "node": ">=12"
+                        },
+                        "funding": {
+                                "url": "https://github.com/sponsors/sindresorhus"
                         }
                 },
                 "node_modules/optionator": {
@@ -1994,7 +2774,6 @@
                         "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
                         "dev": true,
                         "license": "MIT",
-                        "peer": true,
                         "engines": {
                                 "node": ">=8"
                         }
@@ -2009,6 +2788,30 @@
                                 "node": ">=8"
                         }
                 },
+                "node_modules/pathe": {
+                        "version": "1.1.2",
+                        "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+                        "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+                        "dev": true,
+                        "license": "MIT"
+                },
+                "node_modules/pathval": {
+                        "version": "1.1.1",
+                        "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+                        "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+                        "dev": true,
+                        "license": "MIT",
+                        "engines": {
+                                "node": "*"
+                        }
+                },
+                "node_modules/picocolors": {
+                        "version": "1.1.1",
+                        "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+                        "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+                        "dev": true,
+                        "license": "ISC"
+                },
                 "node_modules/picomatch": {
                         "version": "2.3.1",
                         "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -2022,6 +2825,54 @@
                                 "url": "https://github.com/sponsors/jonschlinkert"
                         }
                 },
+                "node_modules/pkg-types": {
+                        "version": "1.3.1",
+                        "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+                        "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "confbox": "^0.1.8",
+                                "mlly": "^1.7.4",
+                                "pathe": "^2.0.1"
+                        }
+                },
+                "node_modules/pkg-types/node_modules/pathe": {
+                        "version": "2.0.3",
+                        "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+                        "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+                        "dev": true,
+                        "license": "MIT"
+                },
+                "node_modules/postcss": {
+                        "version": "8.5.6",
+                        "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+                        "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+                        "dev": true,
+                        "funding": [
+                                {
+                                        "type": "opencollective",
+                                        "url": "https://opencollective.com/postcss/"
+                                },
+                                {
+                                        "type": "tidelift",
+                                        "url": "https://tidelift.com/funding/github/npm/postcss"
+                                },
+                                {
+                                        "type": "github",
+                                        "url": "https://github.com/sponsors/ai"
+                                }
+                        ],
+                        "license": "MIT",
+                        "dependencies": {
+                                "nanoid": "^3.3.11",
+                                "picocolors": "^1.1.1",
+                                "source-map-js": "^1.2.1"
+                        },
+                        "engines": {
+                                "node": "^10 || ^12 || >=14"
+                        }
+                },
                 "node_modules/prelude-ls": {
                         "version": "1.2.1",
                         "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -2031,6 +2882,34 @@
                         "peer": true,
                         "engines": {
                                 "node": ">= 0.8.0"
+                        }
+                },
+                "node_modules/pretty-format": {
+                        "version": "29.7.0",
+                        "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+                        "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "@jest/schemas": "^29.6.3",
+                                "ansi-styles": "^5.0.0",
+                                "react-is": "^18.0.0"
+                        },
+                        "engines": {
+                                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+                        }
+                },
+                "node_modules/pretty-format/node_modules/ansi-styles": {
+                        "version": "5.2.0",
+                        "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+                        "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+                        "dev": true,
+                        "license": "MIT",
+                        "engines": {
+                                "node": ">=10"
+                        },
+                        "funding": {
+                                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
                         }
                 },
                 "node_modules/punycode": {
@@ -2063,6 +2942,13 @@
                                         "url": "https://feross.org/support"
                                 }
                         ],
+                        "license": "MIT"
+                },
+                "node_modules/react-is": {
+                        "version": "18.3.1",
+                        "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+                        "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+                        "dev": true,
                         "license": "MIT"
                 },
                 "node_modules/regexpp": {
@@ -2118,6 +3004,47 @@
                                 "url": "https://github.com/sponsors/isaacs"
                         }
                 },
+                "node_modules/rollup": {
+                        "version": "4.50.2",
+                        "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.50.2.tgz",
+                        "integrity": "sha512-BgLRGy7tNS9H66aIMASq1qSYbAAJV6Z6WR4QYTvj5FgF15rZ/ympT1uixHXwzbZUBDbkvqUI1KR0fH1FhMaQ9w==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "@types/estree": "1.0.8"
+                        },
+                        "bin": {
+                                "rollup": "dist/bin/rollup"
+                        },
+                        "engines": {
+                                "node": ">=18.0.0",
+                                "npm": ">=8.0.0"
+                        },
+                        "optionalDependencies": {
+                                "@rollup/rollup-android-arm-eabi": "4.50.2",
+                                "@rollup/rollup-android-arm64": "4.50.2",
+                                "@rollup/rollup-darwin-arm64": "4.50.2",
+                                "@rollup/rollup-darwin-x64": "4.50.2",
+                                "@rollup/rollup-freebsd-arm64": "4.50.2",
+                                "@rollup/rollup-freebsd-x64": "4.50.2",
+                                "@rollup/rollup-linux-arm-gnueabihf": "4.50.2",
+                                "@rollup/rollup-linux-arm-musleabihf": "4.50.2",
+                                "@rollup/rollup-linux-arm64-gnu": "4.50.2",
+                                "@rollup/rollup-linux-arm64-musl": "4.50.2",
+                                "@rollup/rollup-linux-loong64-gnu": "4.50.2",
+                                "@rollup/rollup-linux-ppc64-gnu": "4.50.2",
+                                "@rollup/rollup-linux-riscv64-gnu": "4.50.2",
+                                "@rollup/rollup-linux-riscv64-musl": "4.50.2",
+                                "@rollup/rollup-linux-s390x-gnu": "4.50.2",
+                                "@rollup/rollup-linux-x64-gnu": "4.50.2",
+                                "@rollup/rollup-linux-x64-musl": "4.50.2",
+                                "@rollup/rollup-openharmony-arm64": "4.50.2",
+                                "@rollup/rollup-win32-arm64-msvc": "4.50.2",
+                                "@rollup/rollup-win32-ia32-msvc": "4.50.2",
+                                "@rollup/rollup-win32-x64-msvc": "4.50.2",
+                                "fsevents": "~2.3.2"
+                        }
+                },
                 "node_modules/run-parallel": {
                         "version": "1.2.0",
                         "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -2161,7 +3088,6 @@
                         "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
                         "dev": true,
                         "license": "MIT",
-                        "peer": true,
                         "dependencies": {
                                 "shebang-regex": "^3.0.0"
                         },
@@ -2175,9 +3101,28 @@
                         "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
                         "dev": true,
                         "license": "MIT",
-                        "peer": true,
                         "engines": {
                                 "node": ">=8"
+                        }
+                },
+                "node_modules/siginfo": {
+                        "version": "2.0.0",
+                        "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+                        "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+                        "dev": true,
+                        "license": "ISC"
+                },
+                "node_modules/signal-exit": {
+                        "version": "4.1.0",
+                        "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+                        "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+                        "dev": true,
+                        "license": "ISC",
+                        "engines": {
+                                "node": ">=14"
+                        },
+                        "funding": {
+                                "url": "https://github.com/sponsors/isaacs"
                         }
                 },
                 "node_modules/slash": {
@@ -2189,6 +3134,30 @@
                         "engines": {
                                 "node": ">=8"
                         }
+                },
+                "node_modules/source-map-js": {
+                        "version": "1.2.1",
+                        "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+                        "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+                        "dev": true,
+                        "license": "BSD-3-Clause",
+                        "engines": {
+                                "node": ">=0.10.0"
+                        }
+                },
+                "node_modules/stackback": {
+                        "version": "0.0.2",
+                        "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+                        "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+                        "dev": true,
+                        "license": "MIT"
+                },
+                "node_modules/std-env": {
+                        "version": "3.9.0",
+                        "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+                        "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+                        "dev": true,
+                        "license": "MIT"
                 },
                 "node_modules/strip-ansi": {
                         "version": "6.0.1",
@@ -2204,6 +3173,19 @@
                                 "node": ">=8"
                         }
                 },
+                "node_modules/strip-final-newline": {
+                        "version": "3.0.0",
+                        "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+                        "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+                        "dev": true,
+                        "license": "MIT",
+                        "engines": {
+                                "node": ">=12"
+                        },
+                        "funding": {
+                                "url": "https://github.com/sponsors/sindresorhus"
+                        }
+                },
                 "node_modules/strip-json-comments": {
                         "version": "3.1.1",
                         "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -2216,6 +3198,19 @@
                         },
                         "funding": {
                                 "url": "https://github.com/sponsors/sindresorhus"
+                        }
+                },
+                "node_modules/strip-literal": {
+                        "version": "2.1.1",
+                        "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+                        "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "js-tokens": "^9.0.1"
+                        },
+                        "funding": {
+                                "url": "https://github.com/sponsors/antfu"
                         }
                 },
                 "node_modules/style-mod": {
@@ -2247,6 +3242,33 @@
                         "dev": true,
                         "license": "MIT",
                         "peer": true
+                },
+                "node_modules/tinybench": {
+                        "version": "2.9.0",
+                        "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+                        "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+                        "dev": true,
+                        "license": "MIT"
+                },
+                "node_modules/tinypool": {
+                        "version": "0.8.4",
+                        "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+                        "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+                        "dev": true,
+                        "license": "MIT",
+                        "engines": {
+                                "node": ">=14.0.0"
+                        }
+                },
+                "node_modules/tinyspy": {
+                        "version": "2.2.1",
+                        "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+                        "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+                        "dev": true,
+                        "license": "MIT",
+                        "engines": {
+                                "node": ">=14.0.0"
+                        }
                 },
                 "node_modules/to-regex-range": {
                         "version": "5.0.1",
@@ -2305,6 +3327,16 @@
                                 "node": ">= 0.8.0"
                         }
                 },
+                "node_modules/type-detect": {
+                        "version": "4.1.0",
+                        "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+                        "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+                        "dev": true,
+                        "license": "MIT",
+                        "engines": {
+                                "node": ">=4"
+                        }
+                },
                 "node_modules/type-fest": {
                         "version": "0.20.2",
                         "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
@@ -2333,6 +3365,20 @@
                                 "node": ">=4.2.0"
                         }
                 },
+                "node_modules/ufo": {
+                        "version": "1.6.1",
+                        "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+                        "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+                        "dev": true,
+                        "license": "MIT"
+                },
+                "node_modules/undici-types": {
+                        "version": "6.21.0",
+                        "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+                        "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+                        "dev": true,
+                        "license": "MIT"
+                },
                 "node_modules/uri-js": {
                         "version": "4.4.1",
                         "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -2342,6 +3388,568 @@
                         "peer": true,
                         "dependencies": {
                                 "punycode": "^2.1.0"
+                        }
+                },
+                "node_modules/vite": {
+                        "version": "5.4.20",
+                        "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+                        "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "esbuild": "^0.21.3",
+                                "postcss": "^8.4.43",
+                                "rollup": "^4.20.0"
+                        },
+                        "bin": {
+                                "vite": "bin/vite.js"
+                        },
+                        "engines": {
+                                "node": "^18.0.0 || >=20.0.0"
+                        },
+                        "funding": {
+                                "url": "https://github.com/vitejs/vite?sponsor=1"
+                        },
+                        "optionalDependencies": {
+                                "fsevents": "~2.3.3"
+                        },
+                        "peerDependencies": {
+                                "@types/node": "^18.0.0 || >=20.0.0",
+                                "less": "*",
+                                "lightningcss": "^1.21.0",
+                                "sass": "*",
+                                "sass-embedded": "*",
+                                "stylus": "*",
+                                "sugarss": "*",
+                                "terser": "^5.4.0"
+                        },
+                        "peerDependenciesMeta": {
+                                "@types/node": {
+                                        "optional": true
+                                },
+                                "less": {
+                                        "optional": true
+                                },
+                                "lightningcss": {
+                                        "optional": true
+                                },
+                                "sass": {
+                                        "optional": true
+                                },
+                                "sass-embedded": {
+                                        "optional": true
+                                },
+                                "stylus": {
+                                        "optional": true
+                                },
+                                "sugarss": {
+                                        "optional": true
+                                },
+                                "terser": {
+                                        "optional": true
+                                }
+                        }
+                },
+                "node_modules/vite-node": {
+                        "version": "1.6.1",
+                        "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+                        "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "cac": "^6.7.14",
+                                "debug": "^4.3.4",
+                                "pathe": "^1.1.1",
+                                "picocolors": "^1.0.0",
+                                "vite": "^5.0.0"
+                        },
+                        "bin": {
+                                "vite-node": "vite-node.mjs"
+                        },
+                        "engines": {
+                                "node": "^18.0.0 || >=20.0.0"
+                        },
+                        "funding": {
+                                "url": "https://opencollective.com/vitest"
+                        }
+                },
+                "node_modules/vite/node_modules/@esbuild/android-arm": {
+                        "version": "0.21.5",
+                        "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+                        "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+                        "cpu": [
+                                "arm"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "android"
+                        ],
+                        "engines": {
+                                "node": ">=12"
+                        }
+                },
+                "node_modules/vite/node_modules/@esbuild/android-arm64": {
+                        "version": "0.21.5",
+                        "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+                        "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+                        "cpu": [
+                                "arm64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "android"
+                        ],
+                        "engines": {
+                                "node": ">=12"
+                        }
+                },
+                "node_modules/vite/node_modules/@esbuild/android-x64": {
+                        "version": "0.21.5",
+                        "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+                        "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+                        "cpu": [
+                                "x64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "android"
+                        ],
+                        "engines": {
+                                "node": ">=12"
+                        }
+                },
+                "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+                        "version": "0.21.5",
+                        "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+                        "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+                        "cpu": [
+                                "arm64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "darwin"
+                        ],
+                        "engines": {
+                                "node": ">=12"
+                        }
+                },
+                "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+                        "version": "0.21.5",
+                        "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+                        "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+                        "cpu": [
+                                "x64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "darwin"
+                        ],
+                        "engines": {
+                                "node": ">=12"
+                        }
+                },
+                "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+                        "version": "0.21.5",
+                        "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+                        "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+                        "cpu": [
+                                "arm64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "freebsd"
+                        ],
+                        "engines": {
+                                "node": ">=12"
+                        }
+                },
+                "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+                        "version": "0.21.5",
+                        "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+                        "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+                        "cpu": [
+                                "x64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "freebsd"
+                        ],
+                        "engines": {
+                                "node": ">=12"
+                        }
+                },
+                "node_modules/vite/node_modules/@esbuild/linux-arm": {
+                        "version": "0.21.5",
+                        "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+                        "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+                        "cpu": [
+                                "arm"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "linux"
+                        ],
+                        "engines": {
+                                "node": ">=12"
+                        }
+                },
+                "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+                        "version": "0.21.5",
+                        "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+                        "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+                        "cpu": [
+                                "arm64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "linux"
+                        ],
+                        "engines": {
+                                "node": ">=12"
+                        }
+                },
+                "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+                        "version": "0.21.5",
+                        "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+                        "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+                        "cpu": [
+                                "ia32"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "linux"
+                        ],
+                        "engines": {
+                                "node": ">=12"
+                        }
+                },
+                "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+                        "version": "0.21.5",
+                        "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+                        "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+                        "cpu": [
+                                "loong64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "linux"
+                        ],
+                        "engines": {
+                                "node": ">=12"
+                        }
+                },
+                "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+                        "version": "0.21.5",
+                        "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+                        "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+                        "cpu": [
+                                "mips64el"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "linux"
+                        ],
+                        "engines": {
+                                "node": ">=12"
+                        }
+                },
+                "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+                        "version": "0.21.5",
+                        "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+                        "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+                        "cpu": [
+                                "ppc64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "linux"
+                        ],
+                        "engines": {
+                                "node": ">=12"
+                        }
+                },
+                "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+                        "version": "0.21.5",
+                        "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+                        "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+                        "cpu": [
+                                "riscv64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "linux"
+                        ],
+                        "engines": {
+                                "node": ">=12"
+                        }
+                },
+                "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+                        "version": "0.21.5",
+                        "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+                        "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+                        "cpu": [
+                                "s390x"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "linux"
+                        ],
+                        "engines": {
+                                "node": ">=12"
+                        }
+                },
+                "node_modules/vite/node_modules/@esbuild/linux-x64": {
+                        "version": "0.21.5",
+                        "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+                        "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+                        "cpu": [
+                                "x64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "linux"
+                        ],
+                        "engines": {
+                                "node": ">=12"
+                        }
+                },
+                "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+                        "version": "0.21.5",
+                        "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+                        "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+                        "cpu": [
+                                "x64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "netbsd"
+                        ],
+                        "engines": {
+                                "node": ">=12"
+                        }
+                },
+                "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+                        "version": "0.21.5",
+                        "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+                        "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+                        "cpu": [
+                                "x64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "openbsd"
+                        ],
+                        "engines": {
+                                "node": ">=12"
+                        }
+                },
+                "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+                        "version": "0.21.5",
+                        "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+                        "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+                        "cpu": [
+                                "x64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "sunos"
+                        ],
+                        "engines": {
+                                "node": ">=12"
+                        }
+                },
+                "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+                        "version": "0.21.5",
+                        "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+                        "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+                        "cpu": [
+                                "arm64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "win32"
+                        ],
+                        "engines": {
+                                "node": ">=12"
+                        }
+                },
+                "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+                        "version": "0.21.5",
+                        "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+                        "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+                        "cpu": [
+                                "ia32"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "win32"
+                        ],
+                        "engines": {
+                                "node": ">=12"
+                        }
+                },
+                "node_modules/vite/node_modules/@esbuild/win32-x64": {
+                        "version": "0.21.5",
+                        "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+                        "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+                        "cpu": [
+                                "x64"
+                        ],
+                        "dev": true,
+                        "license": "MIT",
+                        "optional": true,
+                        "os": [
+                                "win32"
+                        ],
+                        "engines": {
+                                "node": ">=12"
+                        }
+                },
+                "node_modules/vite/node_modules/esbuild": {
+                        "version": "0.21.5",
+                        "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+                        "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+                        "dev": true,
+                        "hasInstallScript": true,
+                        "license": "MIT",
+                        "bin": {
+                                "esbuild": "bin/esbuild"
+                        },
+                        "engines": {
+                                "node": ">=12"
+                        },
+                        "optionalDependencies": {
+                                "@esbuild/aix-ppc64": "0.21.5",
+                                "@esbuild/android-arm": "0.21.5",
+                                "@esbuild/android-arm64": "0.21.5",
+                                "@esbuild/android-x64": "0.21.5",
+                                "@esbuild/darwin-arm64": "0.21.5",
+                                "@esbuild/darwin-x64": "0.21.5",
+                                "@esbuild/freebsd-arm64": "0.21.5",
+                                "@esbuild/freebsd-x64": "0.21.5",
+                                "@esbuild/linux-arm": "0.21.5",
+                                "@esbuild/linux-arm64": "0.21.5",
+                                "@esbuild/linux-ia32": "0.21.5",
+                                "@esbuild/linux-loong64": "0.21.5",
+                                "@esbuild/linux-mips64el": "0.21.5",
+                                "@esbuild/linux-ppc64": "0.21.5",
+                                "@esbuild/linux-riscv64": "0.21.5",
+                                "@esbuild/linux-s390x": "0.21.5",
+                                "@esbuild/linux-x64": "0.21.5",
+                                "@esbuild/netbsd-x64": "0.21.5",
+                                "@esbuild/openbsd-x64": "0.21.5",
+                                "@esbuild/sunos-x64": "0.21.5",
+                                "@esbuild/win32-arm64": "0.21.5",
+                                "@esbuild/win32-ia32": "0.21.5",
+                                "@esbuild/win32-x64": "0.21.5"
+                        }
+                },
+                "node_modules/vitest": {
+                        "version": "1.6.1",
+                        "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+                        "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "@vitest/expect": "1.6.1",
+                                "@vitest/runner": "1.6.1",
+                                "@vitest/snapshot": "1.6.1",
+                                "@vitest/spy": "1.6.1",
+                                "@vitest/utils": "1.6.1",
+                                "acorn-walk": "^8.3.2",
+                                "chai": "^4.3.10",
+                                "debug": "^4.3.4",
+                                "execa": "^8.0.1",
+                                "local-pkg": "^0.5.0",
+                                "magic-string": "^0.30.5",
+                                "pathe": "^1.1.1",
+                                "picocolors": "^1.0.0",
+                                "std-env": "^3.5.0",
+                                "strip-literal": "^2.0.0",
+                                "tinybench": "^2.5.1",
+                                "tinypool": "^0.8.3",
+                                "vite": "^5.0.0",
+                                "vite-node": "1.6.1",
+                                "why-is-node-running": "^2.2.2"
+                        },
+                        "bin": {
+                                "vitest": "vitest.mjs"
+                        },
+                        "engines": {
+                                "node": "^18.0.0 || >=20.0.0"
+                        },
+                        "funding": {
+                                "url": "https://opencollective.com/vitest"
+                        },
+                        "peerDependencies": {
+                                "@edge-runtime/vm": "*",
+                                "@types/node": "^18.0.0 || >=20.0.0",
+                                "@vitest/browser": "1.6.1",
+                                "@vitest/ui": "1.6.1",
+                                "happy-dom": "*",
+                                "jsdom": "*"
+                        },
+                        "peerDependenciesMeta": {
+                                "@edge-runtime/vm": {
+                                        "optional": true
+                                },
+                                "@types/node": {
+                                        "optional": true
+                                },
+                                "@vitest/browser": {
+                                        "optional": true
+                                },
+                                "@vitest/ui": {
+                                        "optional": true
+                                },
+                                "happy-dom": {
+                                        "optional": true
+                                },
+                                "jsdom": {
+                                        "optional": true
+                                }
                         }
                 },
                 "node_modules/w3c-keyname": {
@@ -2358,7 +3966,6 @@
                         "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
                         "dev": true,
                         "license": "ISC",
-                        "peer": true,
                         "dependencies": {
                                 "isexe": "^2.0.0"
                         },
@@ -2367,6 +3974,23 @@
                         },
                         "engines": {
                                 "node": ">= 8"
+                        }
+                },
+                "node_modules/why-is-node-running": {
+                        "version": "2.3.0",
+                        "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+                        "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "siginfo": "^2.0.0",
+                                "stackback": "0.0.2"
+                        },
+                        "bin": {
+                                "why-is-node-running": "cli.js"
+                        },
+                        "engines": {
+                                "node": ">=8"
                         }
                 },
                 "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "scripts": {
                 "dev": "node esbuild.config.mjs",
                 "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
+                "test": "vitest run",
                 "version": "node version-bump.mjs && git add manifest.json versions.json"
         },
         "keywords": [
@@ -18,13 +19,14 @@
         "author": "",
         "license": "MIT",
         "devDependencies": {
-                "@types/node": "^16.11.6",
+                "@types/node": "^20.12.7",
                 "@typescript-eslint/eslint-plugin": "5.29.0",
                 "@typescript-eslint/parser": "5.29.0",
                 "builtin-modules": "3.3.0",
                 "esbuild": "0.17.3",
                 "obsidian": "latest",
                 "tslib": "2.4.0",
-                "typescript": "4.7.4"
+                "typescript": "4.7.4",
+                "vitest": "^1.4.0"
         }
 }

--- a/src/utils/note.ts
+++ b/src/utils/note.ts
@@ -1,0 +1,69 @@
+import { AudioFormat } from "../settings";
+import { formatDateTimeISO } from "./time";
+
+export interface ComposeMeetingNoteParams {
+  title: string;
+  audioVaultPath: string;
+  transcriptVaultPath: string;
+  summaryMarkdown: string;
+  transcript: string;
+  startedAt: Date;
+  durationMs: number;
+}
+
+export interface ComposeMeetingNoteOptions {
+  includeTranscript: boolean;
+}
+
+export function composeMeetingNote(
+  params: ComposeMeetingNoteParams,
+  options: ComposeMeetingNoteOptions,
+): string {
+  const durationText = formatDurationText(params.durationMs);
+  const createdIso = formatDateTimeISO(params.startedAt);
+  const resources: string[] = [`- [[${params.audioVaultPath}|Audio recording]]`];
+  if (params.transcriptVaultPath) {
+    resources.push(`- [[${params.transcriptVaultPath}|Transcript]]`);
+  }
+
+  const summaryContent = params.summaryMarkdown.trim().length > 0
+    ? params.summaryMarkdown.trim()
+    : "*No summary generated.*";
+
+  const sections = [
+    "---",
+    `created: ${createdIso}`,
+    `audio: [[${params.audioVaultPath}]]`,
+    `transcript: [[${params.transcriptVaultPath}]]`,
+    "---",
+    `# ${params.title}`,
+    `**Recorded:** ${params.startedAt.toLocaleString()} (${durationText})`,
+    "## Resources",
+    resources.join("\n"),
+    summaryContent,
+  ];
+
+  if (options.includeTranscript) {
+    sections.push("## Transcript");
+    sections.push(params.transcript.trim());
+  }
+
+  return sections.join("\n\n").trimEnd() + "\n";
+}
+
+export function getAudioMimeType(format: AudioFormat): string {
+  if (format === "ogg") {
+    return "audio/ogg;codecs=opus";
+  }
+  return "audio/webm;codecs=opus";
+}
+
+export function formatDurationText(durationMs: number): string {
+  const totalSeconds = Math.max(1, Math.round(durationMs / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes > 0) {
+    return `${minutes}m ${seconds.toString().padStart(2, "0")}s`;
+  }
+  return `${seconds}s`;
+}

--- a/tests/ai.test.ts
+++ b/tests/ai.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const runCommandMock = vi.fn();
+const accessMock = vi.fn();
+const readFileMock = vi.fn();
+
+vi.mock("../src/utils/command", () => ({
+  runCommand: runCommandMock,
+}));
+
+vi.mock("fs", () => ({
+  promises: {
+    access: accessMock,
+    readFile: readFileMock,
+  },
+}));
+
+const { summarizeTranscript } = await import("../src/ai/summarizer");
+const { transcribeAudio } = await import("../src/ai/transcription");
+
+describe("summarizeTranscript", () => {
+  beforeEach(() => {
+    runCommandMock.mockReset();
+  });
+
+  it("passes prompt to command ensuring trailing newline", async () => {
+    runCommandMock.mockResolvedValue({ stdout: " Summary text \n", stderr: "", exitCode: 0 });
+
+    const result = await summarizeTranscript({
+      command: "ollama",
+      args: ["run", "llama3"],
+      prompt: "Create summary",
+    });
+
+    expect(runCommandMock).toHaveBeenCalledWith("ollama", ["run", "llama3"], { input: "Create summary\n" });
+    expect(result).toBe("Summary text");
+  });
+
+  it("does not duplicate newline when prompt already ends with one", async () => {
+    runCommandMock.mockResolvedValue({ stdout: "Done", stderr: "", exitCode: 0 });
+
+    await summarizeTranscript({ command: "cmd", args: [], prompt: "hello\n" });
+    expect(runCommandMock).toHaveBeenCalledWith("cmd", [], { input: "hello\n" });
+  });
+});
+
+describe("transcribeAudio", () => {
+  beforeEach(() => {
+    runCommandMock.mockReset();
+    accessMock.mockReset();
+    readFileMock.mockReset();
+  });
+
+  it("returns transcript contents from generated file", async () => {
+    runCommandMock.mockResolvedValue({ stdout: "", stderr: "", exitCode: 0 });
+    accessMock.mockResolvedValue(undefined);
+    readFileMock.mockResolvedValue("Transcribed text");
+
+    const result = await transcribeAudio({
+      command: "whisper",
+      args: ["--model", "base"],
+      audioFilePath: "/tmp/audio.webm",
+      outputDir: "/tmp/out",
+      outputFormat: "txt",
+    });
+
+    expect(runCommandMock).toHaveBeenCalledWith("whisper", ["--model", "base"]);
+    expect(accessMock).toHaveBeenCalledWith("/tmp/out/audio.txt");
+    expect(result).toEqual({ transcript: "Transcribed text", transcriptFilePath: "/tmp/out/audio.txt" });
+  });
+
+  it("throws when transcript file is missing", async () => {
+    runCommandMock.mockResolvedValue({ stdout: "", stderr: "", exitCode: 0 });
+    accessMock.mockRejectedValue(new Error("missing"));
+
+    await expect(
+      transcribeAudio({
+        command: "whisper",
+        args: [],
+        audioFilePath: "audio.webm",
+        outputDir: "/tmp/out",
+        outputFormat: "txt",
+      }),
+    ).rejects.toThrow("Transcription output not found");
+  });
+});

--- a/tests/command.test.ts
+++ b/tests/command.test.ts
@@ -1,0 +1,91 @@
+import { EventEmitter } from "events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("child_process", () => ({
+  spawn: spawnMock,
+}));
+
+import { CommandExecutionError, runCommand, splitCommandLine } from "../src/utils/command";
+
+class MockChildProcess extends EventEmitter {
+  stdout = new EventEmitter();
+
+  stderr = new EventEmitter();
+
+  stdin = {
+    write: vi.fn(),
+    end: vi.fn(),
+  };
+}
+
+describe("splitCommandLine", () => {
+  it("splits arguments respecting quotes", () => {
+    const result = splitCommandLine('--model "base english" --flag');
+    expect(result).toEqual(["--model", "base english", "--flag"]);
+  });
+
+  it("handles escaped characters and whitespace", () => {
+    const result = splitCommandLine("run \\\"quoted\\\" 'single value' plain");
+    expect(result).toEqual(["run", '"quoted"', "single value", "plain"]);
+  });
+});
+
+describe("runCommand", () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+  });
+
+  it("returns stdout and stderr for successful execution", async () => {
+    const child = new MockChildProcess();
+    spawnMock.mockReturnValue(child as unknown as NodeJS.ChildProcess);
+
+    const promise = runCommand("cmd", ["arg1"]);
+    child.stdout.emit("data", Buffer.from("output"));
+    child.stderr.emit("data", Buffer.from("warn"));
+    child.emit("close", 0);
+
+    const result = await promise;
+    expect(result).toEqual({ stdout: "output", stderr: "warn", exitCode: 0 });
+    expect(spawnMock).toHaveBeenCalledWith("cmd", ["arg1"], expect.objectContaining({ shell: false }));
+  });
+
+  it("writes provided input to stdin", async () => {
+    const child = new MockChildProcess();
+    spawnMock.mockReturnValue(child as unknown as NodeJS.ChildProcess);
+
+    const promise = runCommand("cmd", [], { input: "hello" });
+    child.emit("close", 0);
+
+    await promise;
+    expect(child.stdin.write).toHaveBeenCalledWith("hello");
+    expect(child.stdin.end).toHaveBeenCalled();
+  });
+
+  it("rejects with errors emitted by the child process", async () => {
+    const child = new MockChildProcess();
+    spawnMock.mockReturnValue(child as unknown as NodeJS.ChildProcess);
+
+    const promise = runCommand("cmd", []);
+    const error = new Error("spawn failed");
+    child.emit("error", error);
+
+    await expect(promise).rejects.toBe(error);
+  });
+
+  it("rejects with CommandExecutionError when exit code is non-zero", async () => {
+    const child = new MockChildProcess();
+    spawnMock.mockReturnValue(child as unknown as NodeJS.ChildProcess);
+
+    const promise = runCommand("cmd", []);
+    child.stdout.emit("data", Buffer.from("out"));
+    child.stderr.emit("data", Buffer.from("err"));
+    child.emit("close", 2);
+
+    await expect(promise).rejects.toBeInstanceOf(CommandExecutionError);
+    await promise.catch((error) => {
+      expect(error).toMatchObject({ exitCode: 2, stdout: "out", stderr: "err" });
+    });
+  });
+});

--- a/tests/files.test.ts
+++ b/tests/files.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { App, FileSystemAdapter, TFile, normalizePath } from "obsidian";
+import {
+  absolutePathToVaultPath,
+  ensureFolder,
+  getAbsolutePath,
+  joinVaultPath,
+  saveBinaryFile,
+  saveTextFile,
+} from "../src/utils/files";
+
+class MockFileSystemAdapter extends FileSystemAdapter {
+  folders: Set<string>;
+
+  constructor(basePath: string, folders: Iterable<string> = []) {
+    super(basePath);
+    this.folders = new Set(Array.from(folders, (folder) => normalizePath(folder)));
+  }
+
+  async exists(path: string) {
+    return this.folders.has(normalizePath(path));
+  }
+}
+
+type StoredFile = TFile & { data: string | ArrayBuffer | null };
+
+function createEnvironment(initialFolders: string[] = []) {
+  const folders = new Set(initialFolders.map((folder) => normalizePath(folder)));
+  const adapter = new MockFileSystemAdapter("/vault", folders);
+  const files = new Map<string, StoredFile>();
+
+  const createFolder = vi.fn(async (path: string) => {
+    const normalized = normalizePath(path);
+    folders.add(normalized);
+    adapter.folders.add(normalized);
+  });
+
+  const getAbstractFileByPath = vi.fn((path: string) => files.get(normalizePath(path)) ?? null);
+
+  const createBinary = vi.fn(async (path: string, data: ArrayBuffer) => {
+    const normalized = normalizePath(path);
+    const file = new TFile(normalized) as StoredFile;
+    file.data = data;
+    files.set(normalized, file);
+    return file;
+  });
+
+  const modifyBinary = vi.fn(async (file: StoredFile, data: ArrayBuffer) => {
+    file.data = data;
+    return file;
+  });
+
+  const create = vi.fn(async (path: string, content: string) => {
+    const normalized = normalizePath(path);
+    const file = new TFile(normalized) as StoredFile;
+    file.data = content;
+    files.set(normalized, file);
+    return file;
+  });
+
+  const modify = vi.fn(async (file: StoredFile, content: string) => {
+    file.data = content;
+    return file;
+  });
+
+  const vault = {
+    adapter,
+    createFolder,
+    getAbstractFileByPath,
+    createBinary,
+    modifyBinary,
+    create,
+    modify,
+  };
+
+  const app = { vault } as unknown as App;
+
+  return { app, adapter, folders, files, vault };
+}
+
+describe("file utilities", () => {
+  let env: ReturnType<typeof createEnvironment>;
+
+  beforeEach(() => {
+    env = createEnvironment(["AI Meeting Notes"]);
+  });
+
+  it("creates missing nested folders", async () => {
+    await ensureFolder(env.app, "AI Meeting Notes/Audio");
+
+    expect(env.vault.createFolder).toHaveBeenCalledTimes(1);
+    expect(env.vault.createFolder).toHaveBeenCalledWith("AI Meeting Notes/Audio");
+    expect(env.adapter.folders.has("AI Meeting Notes/Audio")).toBe(true);
+  });
+
+  it("ignores empty folder paths", async () => {
+    await ensureFolder(env.app, "");
+    await ensureFolder(env.app, undefined);
+
+    expect(env.vault.createFolder).not.toHaveBeenCalled();
+  });
+
+  it("joins vault paths correctly", () => {
+    expect(joinVaultPath("folder", "file.md")).toBe("folder/file.md");
+    expect(joinVaultPath("", "file.md")).toBe("file.md");
+  });
+
+  it("resolves absolute paths when adapter is filesystem based", () => {
+    expect(getAbsolutePath(env.app, "folder/file.md")).toBe("/vault/folder/file.md");
+    expect(getAbsolutePath(env.app, ".")).toBe("/vault");
+  });
+
+  it("converts absolute paths to vault-relative paths", () => {
+    const result = absolutePathToVaultPath(env.app, "/vault/sub/file.md");
+    expect(result).toBe("sub/file.md");
+  });
+
+  it("creates binary files when they do not exist", async () => {
+    const buffer = new ArrayBuffer(8);
+    const file = await saveBinaryFile(env.app, "audio.webm", buffer);
+
+    expect(env.vault.createBinary).toHaveBeenCalledWith("audio.webm", buffer);
+    expect(env.files.get("audio.webm")).toBe(file);
+  });
+
+  it("updates binary files when they already exist", async () => {
+    const existing = new TFile("audio.webm") as StoredFile;
+    env.files.set("audio.webm", existing);
+
+    const buffer = new ArrayBuffer(4);
+    const file = await saveBinaryFile(env.app, "audio.webm", buffer);
+
+    expect(env.vault.modifyBinary).toHaveBeenCalledWith(existing, buffer);
+    expect(file).toBe(existing);
+  });
+
+  it("creates and updates text files", async () => {
+    const created = await saveTextFile(env.app, "notes/note.md", "hello");
+    expect(env.vault.create).toHaveBeenCalledWith("notes/note.md", "hello");
+
+    const existing = created as StoredFile;
+    env.files.set("notes/note.md", existing);
+    const updated = await saveTextFile(env.app, "notes/note.md", "updated");
+
+    expect(env.vault.modify).toHaveBeenCalledWith(existing, "updated");
+    expect(updated).toBe(existing);
+    expect(env.files.get("notes/note.md")).toBe(existing);
+  });
+});

--- a/tests/mocks/obsidian.ts
+++ b/tests/mocks/obsidian.ts
@@ -1,0 +1,31 @@
+export class TAbstractFile {
+  path: string;
+
+  constructor(path: string) {
+    this.path = normalizePath(path);
+  }
+}
+
+export class TFile extends TAbstractFile {
+  data: string | ArrayBuffer | null = null;
+}
+
+export class FileSystemAdapter {
+  constructor(private basePath: string) {}
+
+  getBasePath(): string {
+    return this.basePath;
+  }
+}
+
+export class App {
+  vault: any;
+
+  constructor() {
+    this.vault = {};
+  }
+}
+
+export function normalizePath(value: string): string {
+  return value.replace(/\\/g, "/");
+}

--- a/tests/note.test.ts
+++ b/tests/note.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { composeMeetingNote, formatDurationText, getAudioMimeType } from "../src/utils/note";
+
+describe("note utilities", () => {
+  it("builds a note including transcript when requested", () => {
+    const startedAt = new Date("2024-01-02T03:04:05Z");
+    const localeString = startedAt.toLocaleString();
+    const content = composeMeetingNote(
+      {
+        title: "Meeting Alpha",
+        audioVaultPath: "AI Meeting Notes/Audio/meeting.webm",
+        transcriptVaultPath: "AI Meeting Notes/Transcripts/meeting.txt",
+        summaryMarkdown: "## Summary\n- Discussed roadmap",
+        transcript: "Speaker: Hello",
+        startedAt,
+        durationMs: 65000,
+      },
+      { includeTranscript: true },
+    );
+
+    expect(content).toContain("# Meeting Alpha");
+    expect(content).toContain(`**Recorded:** ${localeString} (1m 05s)`);
+    expect(content).toContain("## Resources");
+    expect(content).toContain("[[AI Meeting Notes/Audio/meeting.webm|Audio recording]]");
+    expect(content).toContain("[[AI Meeting Notes/Transcripts/meeting.txt|Transcript]]");
+    expect(content).toContain("## Summary\n- Discussed roadmap");
+    expect(content).toContain("## Transcript");
+    expect(content).toContain("Speaker: Hello");
+    expect(content.endsWith("\n")).toBe(true);
+  });
+
+  it("omits transcript section when disabled and fills summary fallback", () => {
+    const startedAt = new Date("2024-01-02T03:04:05Z");
+    const content = composeMeetingNote(
+      {
+        title: "Meeting Beta",
+        audioVaultPath: "audio.webm",
+        transcriptVaultPath: "",
+        summaryMarkdown: " ",
+        transcript: "",
+        startedAt,
+        durationMs: 3000,
+      },
+      { includeTranscript: false },
+    );
+
+    expect(content).not.toContain("## Transcript");
+    expect(content).toContain("*No summary generated.*");
+    expect(content).toContain("audio: [[audio.webm]]");
+    expect(content).toContain("transcript: [[]]");
+  });
+
+  it("computes duration text", () => {
+    expect(formatDurationText(0)).toBe("1s");
+    expect(formatDurationText(59000)).toBe("59s");
+    expect(formatDurationText(61000)).toBe("1m 01s");
+    expect(formatDurationText(130000)).toBe("2m 10s");
+  });
+
+  it("returns appropriate MIME types for audio formats", () => {
+    expect(getAudioMimeType("webm")).toBe("audio/webm;codecs=opus");
+    expect(getAudioMimeType("ogg")).toBe("audio/ogg;codecs=opus");
+  });
+});

--- a/tests/template.test.ts
+++ b/tests/template.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { formatTemplate } from "../src/utils/template";
+
+describe("formatTemplate", () => {
+  it("replaces placeholders with provided values", () => {
+    const template = "Hello {{name}}, welcome to {{place}}!";
+    const result = formatTemplate(template, { name: "Alice", place: "Wonderland" });
+    expect(result).toBe("Hello Alice, welcome to Wonderland!");
+  });
+
+  it("omits placeholders with undefined values", () => {
+    const template = "Value: {{defined}} Missing: {{missing}}.";
+    const result = formatTemplate(template, { defined: "here", missing: undefined });
+    expect(result).toBe("Value: here Missing: .");
+  });
+
+  it("supports dotted keys and numeric values", () => {
+    const template = "Path: {{file.name}} Count: {{count}}";
+    const result = formatTemplate(template, { "file.name": "note.md", count: 3 });
+    expect(result).toBe("Path: note.md Count: 3");
+  });
+});

--- a/tests/time.test.ts
+++ b/tests/time.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { formatDateForFile, formatDateTimeISO } from "../src/utils/time";
+
+describe("time utils", () => {
+  it("formats date for filenames with zero padding", () => {
+    const date = new Date("2024-03-05T07:08:09Z");
+    const result = formatDateForFile(date);
+    expect(result).toBe("2024-03-05 07-08-09");
+  });
+
+  it("delegates to toISOString for ISO format", () => {
+    const date = new Date();
+    expect(formatDateTimeISO(date)).toBe(date.toISOString());
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,21 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+    coverage: {
+      enabled: false,
+    },
+  },
+  resolve: {
+    alias: {
+      obsidian: resolve(__dirname, "tests/mocks/obsidian.ts"),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- refactor note composition and audio MIME helper into reusable utilities
- add a Vitest configuration with an Obsidian runtime stub and targeted unit tests
- wire the plugin to the new helpers and expose `npm run test` via package scripts

## Testing
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9fcc7bab88328821771b476586310